### PR TITLE
Add option to handle spill structure 

### DIFF
--- a/bin/run_larnd2supera.py
+++ b/bin/run_larnd2supera.py
@@ -52,8 +52,6 @@ if not larnd2supera.config.get_config(data.config):
     print('Invalid configuration option argument:',data.config)
     sys.exit(3)
 
-print('[RUN] event separator:', data.event_separator)
-
 larnd2supera.utils.run_supera(out_file=data.output_filename,
     in_file=args[0],
     config_key=data.config,

--- a/bin/run_larnd2supera.py
+++ b/bin/run_larnd2supera.py
@@ -15,6 +15,8 @@ parser.add_option("-s", "--skip", dest="skip", metavar="INT", default=0,
     help="number of first events to skip")
 parser.add_option("-l", "--log", dest="log_file", metavar="FILE", default='',
     help="the name of a log file to be created. ")
+parser.add_option("-e", "--event_separator", dest="event_separator", metavar="SEP", default='eventID',
+    help="which event separator to use from larnd-sim, eventID (default) or spillID")
 
 (data, args) = parser.parse_args()
 
@@ -50,10 +52,13 @@ if not larnd2supera.config.get_config(data.config):
     print('Invalid configuration option argument:',data.config)
     sys.exit(3)
 
+print('[RUN] event separator:', data.event_separator)
+
 larnd2supera.utils.run_supera(out_file=data.output_filename,
     in_file=args[0],
     config_key=data.config,
     num_events=int(data.num_events),
     num_skip=int(data.skip),
     save_log=data.log_file,
+    event_separator=data.event_separator
     )

--- a/python/larnd2supera/config_data/2x2.yaml
+++ b/python/larnd2supera/config_data/2x2.yaml
@@ -1,0 +1,35 @@
+# ===============
+# 2x2.yaml
+# ===============
+
+LogLevel:        DEBUG
+ActiveDetectors: ["TPCActive_shape"]
+MaxSegmentSize:  0.03
+PropertyKeyword: '2x2'
+TileLayout: ''
+DetectorProperties: ''
+ElectronEnergyThreshold: 5
+
+BBoxAlgorithm: BBoxInteraction
+BBoxConfig:
+    LogLevel:   DEBUG
+    Seed:       -1
+    BBoxSize:   [120,120,120]
+    BBoxTop:    [60,103,60]
+    BBoxBottom: [-60,-17,-60]
+    VoxelSize:  [0.4,0.4,0.4]
+    #WorldBoundMax: [-1.e20,-1.e20,-1.e20]
+    #WorldBoundMin: [ 1.e20, 1.e20, 1.e20]
+
+LabelAlgorithm: LArTPCMLReco3D
+LabelConfig:
+    LogLevel: DEBUG
+    DeltaSize:     3
+    ComptonSize:  10
+    LEScatterSize: 2
+    TouchDistance: 1
+    StoreLEScatter:   True
+    SemanticPriority: [1,0,2,3,4]
+    EnergyDepositThreshold: 0.0
+    #WorldBoundMax: [-1.e20,-1.e20,-1.e20]
+    #WorldBoundMin: [ 1.e20, 1.e20, 1.e20]

--- a/python/larnd2supera/reader.py
+++ b/python/larnd2supera/reader.py
@@ -1,6 +1,7 @@
 import h5py as h5
 import numpy as np
 from LarpixParser import event_parser as EventParser
+from LarpixParser.util import detector_configuration
 
 class InputEvent:
     event_id = -1
@@ -70,7 +71,7 @@ class InputReader:
                 packets.append(fin['packets'][:])
                 tracks.append(fin['tracks'][:])
                 trajectories.append(fin['trajectories'][:])
-                trajectories.append(fin['vertices'][:])
+                vertices.append(fin['vertices'][:])
                 if verbose: print('Read-in:',f)
                 
         self._mc_packets_assn = np.concatenate(mc_packets_assn)
@@ -98,14 +99,27 @@ class InputReader:
             print('    Potentially missing %d event IDs %s' % (len(missing_ids),str(missing_ids)))
         
         # create a list of corresponding T0s
-        t0_group = EventParser.get_t0(self._packets)
+        #t0_group = EventParser.get_t0(self._packets)
+
+        t0_group = np.empty(shape=(0,))
+        if self._if_spill:
+            # TODO Hard coding alert!
+            detector = '2x2' 
+            run_config,_ = detector_configuration(detector)
+            t0_group = EventParser.get_t0_spill(self._vertices,run_config)
+            # Match true t0s with reconstructed events
+            t0_group = [t0_group[i] for i in self._event_ids]
+        else:
+            t0_group = EventParser.get_t0(self._packets)
 
         # Assert strong assumptions here
         # Assumption 1: currently we assume T0 is same for all readout groups
-        self._event_t0s = self._correct_t0s(np.unique(t0_group,axis=1),len(self._event_ids))
-        if not self._event_t0s.shape[1]==1:
-            print('    ERROR: found an event with non-unique T0s across readout groups.')
-            raise ValueError('Current code implementation assumes unique T0 per event!')
+        #self._event_t0s = self._correct_t0s(np.unique(t0_group,axis=1),len(self._event_ids))
+        #if not self._event_t0s.shape[1]==1:
+        #    print('    ERROR: found an event with non-unique T0s across readout groups.')
+        #    raise ValueError('Current code implementation assumes unique T0 per event!')
+
+        self._event_t0s = np.unique(t0_group)
 
         # Assumption 2: the number of readout should be same as the number of valid Event IDs
         if not len(self._event_ids) == self._event_t0s.shape[0]:
@@ -126,7 +140,7 @@ class InputReader:
         
         return GetEntry(index_loc[0])
         
-    def GetEntry(self,index):
+    def GetEntry(self,index,event_separator):
         
         if index >= len(self._event_ids):
             print('Entry',index,'is above allowed entry index (<%d)' % len(self._event_ids))
@@ -135,6 +149,8 @@ class InputReader:
         
         # Now return event info for the found index
         result = InputEvent()
+
+        result.event_separator = event_separator
         
         result.event_id = self._event_ids[index]
         result.t0 = self._event_t0s[index]
@@ -144,12 +160,12 @@ class InputReader:
         result.packets = self._packets[mask]
         result.mc_packets_assn = self._mc_packets_assn[mask]
         
-        mask = self._tracks['eventID'] == result.event_id
+        mask = self._tracks[event_separator] == result.event_id
         result.tracks = self._tracks[mask]
         
         result.first_track_id = mask.nonzero()[0][0]
         
-        mask = self._trajectories['eventID'] == result.event_id
+        mask = self._trajectories[event_separator] == result.event_id
         result.trajectories = self._trajectories[mask]
         
         return result  

--- a/python/larnd2supera/reader.py
+++ b/python/larnd2supera/reader.py
@@ -10,17 +10,23 @@ class InputEvent:
     trajectories = None
     t0 = -1
     first_track_id = -1
+    event_separator = ''
 
 class InputReader:
     
-    def __init__(self,input_files=None):
+    def __init__(self,input_files=None,event_separator='eventID'):
         self._mc_packets_assn = None
         self._packets = None
         self._tracks = None
         self._trajectories = None
+        self._vertices = None
         self._packet2event = None
         self._event_ids = None
         self._event_t0s = None
+        self._if_spill = False
+
+        if event_separator == "spillID":
+            self._if_spill = True
         
         if input_files:
             self.ReadFile(input_files)
@@ -53,6 +59,7 @@ class InputReader:
         packets = []
         tracks  = []
         trajectories = []
+        vertices = []
         
         if type(input_files) == str:
             input_files = [input_files]
@@ -63,15 +70,17 @@ class InputReader:
                 packets.append(fin['packets'][:])
                 tracks.append(fin['tracks'][:])
                 trajectories.append(fin['trajectories'][:])
+                trajectories.append(fin['vertices'][:])
                 if verbose: print('Read-in:',f)
                 
         self._mc_packets_assn = np.concatenate(mc_packets_assn)
         self._packets = np.concatenate(packets)
         self._tracks  = np.concatenate(tracks )
         self._trajectories = np.concatenate(trajectories)
+        self._vertices = np.concatenate(vertices)
         
         # create mapping
-        self._packet2event = EventParser.packet_to_eventid(self._mc_packets_assn, self._tracks)
+        self._packet2event = EventParser.packet_to_eventid(self._mc_packets_assn, self._tracks, ifspill=self._if_spill)
         
         packet_mask = self._packet2event != -1
         ctr_packet  = len(self._packets)

--- a/python/larnd2supera/utils.py
+++ b/python/larnd2supera/utils.py
@@ -27,11 +27,12 @@ def run_supera(out_file='larcv.root',
                config_key='',
                num_events=-1,
                num_skip=0,
+               event_separator='eventID',
                save_log=None):
 
     start_time = time.time()
 
-    reader = larnd2supera.reader.InputReader(in_file)
+    reader = larnd2supera.reader.InputReader(in_file,event_separator)
     writer = get_iomanager(out_file)
     driver = get_larnd2supera(config_key)
 
@@ -64,7 +65,7 @@ def run_supera(out_file='larcv.root',
         num_events -= 1 
 
         t0 = time.time()
-        input_data = reader.GetEntry(entry)
+        input_data = reader.GetEntry(entry,event_separator)
         time_read = time.time() - t0
 
         print('Entry {} Event ID {}'.format(entry,input_data.event_id))


### PR DESCRIPTION
- Add a "-e" (aka event_separator) flag to run_larnd2supera.py that can take 'spillID' as in an input value. Defaults to 'eventID'
- Implement new LarpixParser get_t0_spill method to get t0 values for spill structure (only used if event_separator is 'spillID')
- Get vertices dataset from input file, which is necessary for get_t0_spill
- Import LarpixParser's detector_configuration method, which is also necessary for get_t0_spill
- Use event_separator value in GetEntry